### PR TITLE
chore: wire up GCP OAuth client IDs

### DIFF
--- a/v2/apps/extension/wxt.config.ts
+++ b/v2/apps/extension/wxt.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
       'https://www.bing.com/*',
     ],
     oauth2: {
-      client_id: 'PLACEHOLDER.apps.googleusercontent.com',
+      client_id: '603010888709-aedkplba5694rbacksisevfmges8mpak.apps.googleusercontent.com',
       scopes: [
         'https://www.googleapis.com/auth/drive.file',
         'https://www.googleapis.com/auth/userinfo.profile',

--- a/v2/apps/web/lib/web-auth-provider.ts
+++ b/v2/apps/web/lib/web-auth-provider.ts
@@ -1,6 +1,6 @@
 import type { AuthProvider, UserProfile } from '@lumina/drive';
 
-const CLIENT_ID = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID || 'PLACEHOLDER.apps.googleusercontent.com';
+const CLIENT_ID = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID || '603010888709-h4m431c39ar5mbnl10oh5ariq50kp4sq.apps.googleusercontent.com';
 const SCOPES = 'https://www.googleapis.com/auth/drive.file https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email';
 
 let accessToken: string | null = null;


### PR DESCRIPTION
## Summary
- Replace PLACEHOLDER client IDs with real GCP OAuth credentials
- Web: `603010888709-h4m431c39ar5mbnl10oh5ariq50kp4sq.apps.googleusercontent.com`
- Extension: `603010888709-aedkplba5694rbacksisevfmges8mpak.apps.googleusercontent.com`

## Test plan
- [x] `NEXT_PUBLIC_GOOGLE_CLIENT_ID` env var set on Cloudflare Pages
- [x] Extension rebuilt and reloaded in Chrome
- [ ] OAuth sign-in flow verified on web (lumina-new-tab.pages.dev)
- [ ] OAuth sign-in flow verified in extension

🤖 Generated with [Claude Code](https://claude.com/claude-code)