### PR TITLE
fix: wallpaper not rendering after settings change

### DIFF
--- a/v2/apps/extension/entrypoints/newtab/main.tsx
+++ b/v2/apps/extension/entrypoints/newtab/main.tsx
@@ -91,7 +91,10 @@ function NewTab() {
         <>
           <SettingsPanel
             open={activePanel === 'settings'}
-            onClose={() => setActivePanel(null)}
+            onClose={() => {
+              setActivePanel(null);
+              storage.getSettings().then(setSettings);
+            }}
             onSignIn={handleSignIn}
             onSignOut={handleSignOut}
           />

--- a/v2/apps/web/app/page.tsx
+++ b/v2/apps/web/app/page.tsx
@@ -80,7 +80,10 @@ function LuminaApp() {
         <>
           <SettingsPanel
             open={activePanel === 'settings'}
-            onClose={() => setActivePanel(null)}
+            onClose={() => {
+              setActivePanel(null);
+              storage.getSettings().then(setSettings);
+            }}
             onSignIn={handleSignIn}
             onSignOut={handleSignOut}
           />


### PR DESCRIPTION
## Summary
- Re-read settings from storage when settings panel closes so bgMode changes propagate to the wallpaper loading effect

## Test plan
- [ ] Upload wallpaper, activate it, switch to wallpaper mode, close settings — wallpaper should render

🤖 Generated with [Claude Code](https://claude.com/claude-code)