### PR TITLE
fix: drive scope + split view panel with drag resize

### DIFF
--- a/DONE.md
+++ b/DONE.md
@@ -49,6 +49,18 @@ Confirmed Asana's html_notes allowlist has no checkbox markup (kept existing tas
 
 ## Chores
 
+- [x] CHORE: move clear completed tasks by checklist item in toolbar for notes
+
+```RESULT:
+Moved clear completed button from NoteEditor toolbar to NoteTabBar. Editor exposes clearCompleted via forwardRef/useImperativeHandle — commit: c6e3e1b 2026.04.20 12:15:00
+```
+
+- [x] CHORE: main panel should not be covered when notes are expanded, it should be a split view
+
+```RESULT:
+Main content now aligns left with max-width constrained to remaining viewport when panel is open, preventing overlap — commit: f83d6be 2026.04.20 12:25:00
+```
+
 - [x] CHORE: wallpapers need to be able to be removed, also not showing up on main panel
 
 ```RESULT:

--- a/v2/apps/extension/entrypoints/newtab/main.tsx
+++ b/v2/apps/extension/entrypoints/newtab/main.tsx
@@ -1,7 +1,7 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import ReactDOM from 'react-dom/client';
 import { storage, type LuminaSettings, DEFAULT_SETTINGS } from '@lumina/core';
-import { setAuthProvider, setupSyncListeners, onSyncStatus, pullAll } from '@lumina/drive';
+import { setAuthProvider, setupSyncListeners, onSyncStatus, pullAll, markDirty, schedulePush } from '@lumina/drive';
 import {
   LuminaShell, BackgroundCanvas, Clock, SearchBar,
   QuickLinks, FocusLine, Weather, BibleVerse,
@@ -85,11 +85,25 @@ function NewTab() {
     await extensionAuthProvider.signOut();
   }, []);
 
+  const savePanelWidthTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const handlePanelWidthChange = useCallback((width: number) => {
+    setSettings(prev => ({ ...prev, panelWidth: width }));
+    if (savePanelWidthTimer.current) clearTimeout(savePanelWidthTimer.current);
+    savePanelWidthTimer.current = setTimeout(async () => {
+      const s = await storage.getSettings();
+      await storage.setSettings({ ...s, panelWidth: width, updatedAt: new Date().toISOString() });
+      await markDirty('settings');
+      schedulePush();
+    }, 500);
+  }, []);
+
   if (!ready) return null;
 
   return (
     <LuminaShell
       panelOpen={activePanel !== null}
+      panelWidth={settings.panelWidth}
+      onPanelWidthChange={handlePanelWidthChange}
       panel={
         <>
           <SettingsPanel

--- a/v2/apps/extension/wxt.config.ts
+++ b/v2/apps/extension/wxt.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
     oauth2: {
       client_id: '603010888709-aedkplba5694rbacksisevfmges8mpak.apps.googleusercontent.com',
       scopes: [
-        'https://www.googleapis.com/auth/drive.file',
+        'https://www.googleapis.com/auth/drive',
         'https://www.googleapis.com/auth/userinfo.profile',
         'https://www.googleapis.com/auth/userinfo.email',
       ],

--- a/v2/apps/web/app/page.tsx
+++ b/v2/apps/web/app/page.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { storage, type LuminaSettings, DEFAULT_SETTINGS } from '@lumina/core';
+import { markDirty, schedulePush } from '@lumina/drive';
 import { onSyncStatus, pullAll } from '@lumina/drive';
 import { webAuthProvider } from '../lib/web-auth-provider';
 import {
@@ -76,9 +77,23 @@ function LuminaApp() {
     await webAuthProvider.signOut();
   }, []);
 
+  const savePanelWidthTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const handlePanelWidthChange = useCallback((width: number) => {
+    setSettings(prev => ({ ...prev, panelWidth: width }));
+    if (savePanelWidthTimer.current) clearTimeout(savePanelWidthTimer.current);
+    savePanelWidthTimer.current = setTimeout(async () => {
+      const s = await storage.getSettings();
+      await storage.setSettings({ ...s, panelWidth: width, updatedAt: new Date().toISOString() });
+      await markDirty('settings');
+      schedulePush();
+    }, 500);
+  }, []);
+
   return (
     <LuminaShell
       panelOpen={activePanel !== null}
+      panelWidth={settings.panelWidth}
+      onPanelWidthChange={handlePanelWidthChange}
       panel={
         <>
           <SettingsPanel

--- a/v2/apps/web/lib/web-auth-provider.ts
+++ b/v2/apps/web/lib/web-auth-provider.ts
@@ -1,7 +1,7 @@
 import type { AuthProvider, UserProfile } from '@lumina/drive';
 
 const CLIENT_ID = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID || '603010888709-h4m431c39ar5mbnl10oh5ariq50kp4sq.apps.googleusercontent.com';
-const SCOPES = 'https://www.googleapis.com/auth/drive.file https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email';
+const SCOPES = 'https://www.googleapis.com/auth/drive https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email';
 
 let accessToken: string | null = null;
 let tokenClient: google.accounts.oauth2.TokenClient | null = null;

--- a/v2/packages/core/src/defaults.ts
+++ b/v2/packages/core/src/defaults.ts
@@ -19,6 +19,7 @@ export const DEFAULT_SETTINGS: LuminaSettings = {
   greetingCustom: false,
   greetingCustomText: '',
   panelTheme: 'dark',
+  panelWidth: 520,
   notesPanelOpen: true,
   qlIconsOnly: false,
   qlCollapsed: {},

--- a/v2/packages/core/src/types.ts
+++ b/v2/packages/core/src/types.ts
@@ -116,6 +116,7 @@ export interface LuminaSettings {
   greetingCustom: boolean;
   greetingCustomText: string;
   panelTheme: 'dark' | 'light' | 'system';
+  panelWidth: number;
   notesPanelOpen: boolean;
   qlIconsOnly: boolean;
   qlCollapsed: Record<string, boolean>;

--- a/v2/packages/ui/src/components/LuminaShell.module.css
+++ b/v2/packages/ui/src/components/LuminaShell.module.css
@@ -31,13 +31,17 @@
   background-size: 200px 200px;
 }
 
-.grainHidden {
-  display: none;
+.splitContainer {
+  position: relative;
+  z-index: 2;
+  display: flex;
+  min-height: 100vh;
+  width: 100%;
 }
 
 .app {
-  position: relative;
-  z-index: 2;
+  flex: 1;
+  min-width: 0;
   min-height: 100vh;
   display: flex;
   flex-direction: column;
@@ -46,30 +50,44 @@
   width: 100%;
   margin: 0 auto;
   padding: 0 32px 60px;
-  transition: margin 0.35s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-.appPanelOpen {
-  margin-right: clamp(420px, 40vw, 800px);
-  margin-left: 0;
-  max-width: calc(100vw - clamp(420px, 40vw, 800px) - 64px);
+.dragHandle {
+  width: 6px;
+  flex-shrink: 0;
+  cursor: col-resize;
+  background: transparent;
+  position: relative;
+  z-index: 91;
+  transition: background 0.15s;
 }
 
-@media (max-width: 768px) {
-  .appPanelOpen {
-    margin-right: auto;
-    margin-left: auto;
-    max-width: 900px;
-  }
+.dragHandle:hover,
+.dragHandle:active {
+  background: rgba(167, 139, 250, 0.3);
 }
 
 .panel {
-  position: fixed;
-  right: 0;
+  flex-shrink: 0;
+  height: 100vh;
+  position: sticky;
   top: 0;
-  bottom: 0;
-  z-index: 90;
-  width: clamp(420px, 40vw, 800px);
-  max-width: 100vw;
-  pointer-events: none;
+  overflow: hidden;
+}
+
+@media (max-width: 768px) {
+  .splitContainer {
+    flex-direction: column;
+  }
+
+  .panel {
+    width: 100% !important;
+    height: auto;
+    position: relative;
+    max-height: 60vh;
+  }
+
+  .dragHandle {
+    display: none;
+  }
 }

--- a/v2/packages/ui/src/components/LuminaShell.tsx
+++ b/v2/packages/ui/src/components/LuminaShell.tsx
@@ -1,11 +1,16 @@
-import React from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import styles from './LuminaShell.module.css';
+
+const MIN_PANEL = 360;
+const MAX_PANEL = 900;
 
 interface LuminaShellProps {
   children?: React.ReactNode;
   panel?: React.ReactNode;
   canvasSlot?: React.ReactNode;
   panelOpen?: boolean;
+  panelWidth?: number;
+  onPanelWidthChange?: (width: number) => void;
   wallpaperUrl?: string;
   showGrain?: boolean;
 }
@@ -15,9 +20,41 @@ export function LuminaShell({
   panel,
   canvasSlot,
   panelOpen = false,
+  panelWidth = 520,
+  onPanelWidthChange,
   wallpaperUrl,
   showGrain = true,
 }: LuminaShellProps) {
+  const dragging = useRef(false);
+  const [localWidth, setLocalWidth] = useState(panelWidth);
+  const width = panelOpen ? localWidth : 0;
+
+  const onPointerDown = useCallback((e: React.PointerEvent) => {
+    e.preventDefault();
+    dragging.current = true;
+    (e.target as HTMLElement).setPointerCapture(e.pointerId);
+  }, []);
+
+  const onPointerMove = useCallback((e: React.PointerEvent) => {
+    if (!dragging.current) return;
+    const next = Math.min(MAX_PANEL, Math.max(MIN_PANEL, window.innerWidth - e.clientX));
+    setLocalWidth(next);
+  }, []);
+
+  const onPointerUp = useCallback((e: React.PointerEvent) => {
+    if (!dragging.current) return;
+    dragging.current = false;
+    (e.target as HTMLElement).releasePointerCapture(e.pointerId);
+    const next = Math.min(MAX_PANEL, Math.max(MIN_PANEL, window.innerWidth - e.clientX));
+    setLocalWidth(next);
+    onPanelWidthChange?.(next);
+  }, [onPanelWidthChange]);
+
+  // Sync prop → local when not dragging
+  if (panelWidth !== localWidth && !dragging.current) {
+    setLocalWidth(panelWidth);
+  }
+
   return (
     <div className={styles.shell}>
       {canvasSlot}
@@ -33,18 +70,29 @@ export function LuminaShell({
 
       {showGrain && <div className={styles.grain} />}
 
-      <main
-        id="app"
-        className={`${styles.app}${panelOpen ? ` ${styles.appPanelOpen}` : ''}`}
-      >
-        {children}
-      </main>
+      <div className={styles.splitContainer}>
+        <main
+          id="app"
+          className={styles.app}
+          style={panelOpen ? { marginRight: 0, maxWidth: 'none' } : undefined}
+        >
+          {children}
+        </main>
 
-      {panel && (
-        <aside className={styles.panel}>
-          {panel}
-        </aside>
-      )}
+        {panelOpen && (
+          <>
+            <div
+              className={styles.dragHandle}
+              onPointerDown={onPointerDown}
+              onPointerMove={onPointerMove}
+              onPointerUp={onPointerUp}
+            />
+            <aside className={styles.panel} style={{ width }}>
+              {panel}
+            </aside>
+          </>
+        )}
+      </div>
     </div>
   );
 }

--- a/v2/packages/ui/src/components/NotesPanel.tsx
+++ b/v2/packages/ui/src/components/NotesPanel.tsx
@@ -167,12 +167,12 @@ export function NotesPanel({
 
   const activeNote = notes.find(n => n.id === activeNoteId);
 
+  if (!open) return null;
+
   return (
     <div style={{
       ...panelStyle,
       background: t.panelBg,
-      borderLeft: `1px solid ${t.border}`,
-      transform: open ? 'translateX(0)' : 'translateX(100%)',
     }}>
       {/* Panel header */}
       <div style={{ ...panelHeaderStyle, borderBottom: `1px solid ${t.borderSubtle}` }}>
@@ -255,21 +255,13 @@ const MAIN_TABS: { id: NotesPanelTab; label: string }[] = [
 ];
 
 const panelStyle: React.CSSProperties = {
-  position: 'fixed',
-  right: 0,
-  top: 0,
-  bottom: 0,
-  width: 'clamp(420px, 40vw, 800px)',
-  maxWidth: '100vw',
-  zIndex: 90,
+  width: '100%',
+  height: '100%',
   background: 'rgba(14,10,28,0.97)',
-  borderLeft: '1px solid rgba(255,255,255,0.1)',
   backdropFilter: 'blur(20px)',
   display: 'flex',
   flexDirection: 'column',
-  transition: 'transform 0.35s cubic-bezier(0.4,0,0.2,1)',
-  boxShadow: '-4px 0 40px rgba(0,0,0,0.5)',
-  pointerEvents: 'auto',
+  overflow: 'hidden',
 };
 
 const panelHeaderStyle: React.CSSProperties = {

--- a/v2/packages/ui/src/components/SettingsPanel.tsx
+++ b/v2/packages/ui/src/components/SettingsPanel.tsx
@@ -57,24 +57,13 @@ export function SettingsPanel({ open, onClose, onSignIn, onSignOut }: SettingsPa
   const isDark = settings?.panelTheme === 'system' ? systemDark : (settings?.panelTheme ?? 'dark') === 'dark';
   const t = useMemo(() => isDark ? DARK_TOKENS : LIGHT_TOKENS, [isDark]);
 
-  function handleBackdropClick(e: React.MouseEvent) {
-    if (e.target === e.currentTarget) onClose();
-  }
+  if (!open) return null;
 
   return (
-    <>
-      {open && (
-        <div
-          style={overlayStyle}
-          onClick={handleBackdropClick}
-        />
-      )}
-      <div style={{
-        ...panelStyle,
-        background: t.panelBg,
-        borderLeft: `1px solid ${t.border}`,
-        transform: open ? 'translateX(0)' : 'translateX(100%)',
-      }}>
+    <div style={{
+      ...panelStyle,
+      background: t.panelBg,
+    }}>
         <div style={{ ...panelHeaderStyle, borderBottom: `1px solid ${t.borderSubtle}` }}>
           <span style={{ ...panelTitleStyle, color: t.textStrong }}>Settings</span>
           <button style={{ ...closeBtnStyle, color: t.textMuted, borderColor: t.border }} onClick={onClose} title="Close">
@@ -165,7 +154,6 @@ export function SettingsPanel({ open, onClose, onSignIn, onSignOut }: SettingsPa
           )}
         </div>
       </div>
-    </>
   );
 }
 
@@ -181,30 +169,14 @@ const TABS: { id: Tab; label: string }[] = [
   { id: 'sync', label: 'Sync' },
 ];
 
-const overlayStyle: React.CSSProperties = {
-  position: 'fixed',
-  inset: 0,
-  zIndex: 89,
-  background: 'rgba(0,0,0,0.4)',
-  pointerEvents: 'auto',
-};
-
 const panelStyle: React.CSSProperties = {
-  position: 'fixed',
-  right: 0,
-  top: 0,
-  bottom: 0,
-  width: 'clamp(420px, 40vw, 800px)',
-  maxWidth: '100vw',
-  zIndex: 90,
+  width: '100%',
+  height: '100%',
   background: 'rgba(14,10,28,0.97)',
-  borderLeft: '1px solid rgba(255,255,255,0.1)',
   backdropFilter: 'blur(20px)',
   display: 'flex',
   flexDirection: 'column',
-  transition: 'transform 0.35s cubic-bezier(0.4,0,0.2,1)',
-  boxShadow: '-4px 0 40px rgba(0,0,0,0.5)',
-  pointerEvents: 'auto',
+  overflow: 'hidden',
 };
 
 const panelHeaderStyle: React.CSSProperties = {


### PR DESCRIPTION
## Summary
- Fix cross-app sync by switching from drive.file to drive scope
- Convert side panel from fixed overlay to flex split layout with draggable resize handle
- Panel width persists to settings and syncs via Drive
- Archive completed tasks to DONE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)