### PR TITLE
refactor(v1): remove kindling feature (#27)

### DIFF
--- a/v1/background.js
+++ b/v1/background.js
@@ -1,8 +1,7 @@
-/* Lumina — background service worker: context menu + form auto-fill + save to kindling */
+/* Lumina — background service worker: context menu + form auto-fill */
 
 const STORAGE_KEY = 'lumina_address_book';
 const MENU_PARENT = 'lumina-autofill-parent';
-const MENU_SAVE_KINDLING = 'lumina-save-kindling';
 const CONTEXTS = ['all'];
 
 function buildContextMenu(entries) {
@@ -12,12 +11,6 @@ function buildContextMenu(entries) {
       title: 'Lumina: Add to Quick Links',
       contexts: ['page', 'link'],
     });
-    chrome.contextMenus.create({
-      id: MENU_SAVE_KINDLING,
-      title: 'Save to Kindling',
-      contexts: ['page', 'link'],
-    });
-
     chrome.contextMenus.create({
       id: MENU_PARENT,
       title: 'Lumina: Auto-fill form with',
@@ -104,14 +97,6 @@ chrome.contextMenus.onClicked.addListener((info, tab) => {
     return;
   }
   if (!info.menuItemId || info.menuItemId === MENU_PARENT) return;
-
-  if (info.menuItemId === MENU_SAVE_KINDLING) {
-    const url = info.linkUrl || info.pageUrl || tab?.url || '';
-    const title = tab?.title || '';
-    if (!url) return;
-    saveToKindling(url, title);
-    return;
-  }
 
   if (info.menuItemId === 'lumina-autofill-empty') {
     chrome.tabs.create({ url: chrome.runtime.getURL('newtab.html') });
@@ -241,55 +226,3 @@ function fillFormWithEntry(entry) {
   if (firstFilled) firstFilled.focus();
 }
 
-async function saveToKindling(url, title) {
-  if (!title) {
-    try { title = new URL(url).hostname.replace(/^www\./, ''); }
-    catch { title = url; }
-  }
-
-  const link = {
-    id: 'sl-' + Date.now(),
-    url,
-    title,
-    tags: [],
-    savedAt: Date.now(),
-  };
-
-  const result = await chrome.storage.local.get('lumina_saved');
-  const savedData = result.lumina_saved || { links: [], tags: [] };
-  savedData.links.push(link);
-  await chrome.storage.local.set({ lumina_saved: savedData });
-
-  try {
-    const token = (await chrome.storage.local.get('lumina_raindrop_token')).lumina_raindrop_token;
-    const raw = (await chrome.storage.local.get('lumina_raindrop_collection')).lumina_raindrop_collection;
-    const collectionId = typeof raw === 'string' ? JSON.parse(raw) : raw;
-    if (!token || !collectionId) return;
-    const resp = await fetch('https://api.raindrop.io/rest/v1/raindrop', {
-      method: 'POST',
-      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json', Accept: 'application/json' },
-      body: JSON.stringify({
-        link: url,
-        title: title,
-        collection: { '$id': collectionId },
-        tags: [],
-        important: true,
-      }),
-    });
-    if (resp.ok) {
-      const j = await resp.json();
-      if (j?.item?._id) {
-        link.raindropId = j.item._id;
-        link.id = 'sl-' + j.item._id;
-        link.lastUpdate = j.item.lastUpdate || new Date().toISOString();
-        const freshResult = await chrome.storage.local.get('lumina_saved');
-        const freshData = freshResult.lumina_saved || savedData;
-        const idx = freshData.links.findIndex(l => l.url === url && !l.raindropId);
-        if (idx >= 0) {
-          freshData.links[idx] = link;
-          await chrome.storage.local.set({ lumina_saved: freshData });
-        }
-      }
-    }
-  } catch {}
-}

--- a/v1/newtab.html
+++ b/v1/newtab.html
@@ -2765,266 +2765,6 @@
       margin: 3px 0 4px;
     }
 
-    /* ─── SAVED LINKS IN PANEL ─── */
-    #saved-add-row {
-      padding: 14px 20px 0;
-      flex-shrink: 0;
-    }
-
-    #saved-add-btn {
-      width: 100%;
-      background: rgba(167, 139, 250, 0.08);
-      border: 1px dashed rgba(167, 139, 250, 0.3);
-      color: var(--accent);
-      border-radius: 10px;
-      padding: 9px;
-      font-family: 'Inter', sans-serif;
-      font-size: 12px;
-      font-weight: 500;
-      cursor: pointer;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      gap: 6px;
-      transition: all 0.2s;
-    }
-
-    #saved-add-btn:hover {
-      background: rgba(167, 139, 250, 0.16);
-      border-color: rgba(167, 139, 250, 0.5);
-    }
-
-    #saved-filters {
-      display: flex;
-      gap: 6px;
-      padding: 12px 20px 0;
-      overflow-x: auto;
-      flex-shrink: 0;
-      scrollbar-width: none;
-    }
-
-    #saved-filters::-webkit-scrollbar {
-      display: none;
-    }
-
-    .saved-filter-chip {
-      padding: 4px 12px;
-      border-radius: 20px;
-      border: 1px solid var(--glass-border);
-      background: var(--glass);
-      color: var(--text-muted);
-      cursor: pointer;
-      font-size: 11px;
-      font-weight: 500;
-      white-space: nowrap;
-      font-family: 'Inter', sans-serif;
-      transition: all 0.15s;
-      display: flex;
-      align-items: center;
-      gap: 5px;
-    }
-
-    .saved-filter-chip:hover {
-      background: var(--glass-hover);
-      color: var(--text);
-    }
-
-    #saved-list {
-      flex: 1;
-      overflow-y: auto;
-      padding: 10px 14px;
-      min-height: 0;
-      display: flex;
-      flex-direction: column;
-      gap: 5px;
-    }
-
-    #saved-empty {
-      text-align: center;
-      padding: 36px 20px;
-      color: var(--text-muted);
-      font-size: 13px;
-      line-height: 1.7;
-      border: 1px dashed var(--glass-border);
-      border-radius: var(--r);
-      margin-top: 8px;
-    }
-
-    .saved-item {
-      background: var(--glass);
-      border: 1px solid var(--glass-border);
-      border-radius: 12px;
-      padding: 10px 12px;
-      display: flex;
-      align-items: center;
-      gap: 10px;
-      cursor: pointer;
-      text-decoration: none;
-      transition: background 0.2s, transform 0.15s, border-color 0.2s;
-      animation: cardIn 0.25s ease both;
-    }
-
-    .saved-item:hover {
-      background: var(--glass-hover);
-      transform: translateY(-1px);
-      border-color: rgba(255, 255, 255, 0.18);
-    }
-
-    .saved-item-favicon {
-      width: 24px;
-      height: 24px;
-      border-radius: 6px;
-      flex-shrink: 0;
-      object-fit: cover;
-      background: var(--saved-favicon-bg, rgba(255, 255, 255, 0.92));
-    }
-
-    .fav-bg-btn {
-      width: 22px;
-      height: 22px;
-      border-radius: 5px;
-      border: 1.5px solid var(--glass-border);
-      cursor: pointer;
-      flex-shrink: 0;
-      padding: 0;
-      transition: border-color 0.15s;
-    }
-
-    .fav-bg-btn[data-bg="white"] {
-      background: rgba(255, 255, 255, 0.85);
-    }
-
-    .fav-bg-btn[data-bg="dark"] {
-      background: rgba(20, 15, 40, 0.75);
-    }
-
-    .fav-bg-btn[data-bg="transparent"] {
-      background: transparent;
-      background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.1) 25%, transparent 25%, transparent 75%, rgba(255, 255, 255, 0.1) 75%), linear-gradient(45deg, rgba(255, 255, 255, 0.1) 25%, transparent 25%, transparent 75%, rgba(255, 255, 255, 0.1) 75%);
-      background-size: 8px 8px;
-      background-position: 0 0, 4px 4px;
-    }
-
-    .fav-bg-btn.active {
-      border-color: var(--accent);
-    }
-
-    .saved-item-favicon.fallback {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 11px;
-      font-weight: 600;
-      color: var(--text-muted);
-      font-family: 'Inter', sans-serif;
-    }
-
-    .saved-item-info {
-      flex: 1;
-      min-width: 0;
-    }
-
-    .saved-item-title {
-      font-size: 12px;
-      font-weight: 500;
-      color: var(--text);
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-    }
-
-    .saved-item-domain {
-      font-size: 10px;
-      color: var(--text-muted);
-      margin-top: 1px;
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-    }
-
-    .saved-item-tags {
-      display: flex;
-      gap: 3px;
-      flex-wrap: wrap;
-      margin-top: 4px;
-    }
-
-    .saved-tag-chip {
-      display: inline-flex;
-      align-items: center;
-      font-size: 9px;
-      font-weight: 600;
-      letter-spacing: 0.04em;
-      padding: 2px 7px;
-      border-radius: 10px;
-      font-family: 'Inter', sans-serif;
-      border: 1px solid transparent;
-    }
-
-    .saved-item-actions {
-      display: flex;
-      gap: 2px;
-      flex-shrink: 0;
-    }
-
-    .saved-item-edit,
-    .saved-item-copy,
-    .saved-item-delete {
-      background: none;
-      border: none;
-      color: transparent;
-      cursor: pointer;
-      padding: 4px;
-      border-radius: 5px;
-      font-size: 12px;
-      transition: color 0.15s, background 0.15s;
-      flex-shrink: 0;
-    }
-
-    .saved-item-read {
-      padding: 4px;
-      background: none;
-      border: none;
-      border-radius: 5px;
-      display: inline-flex;
-      color: var(--text-muted);
-      cursor: pointer;
-      transition: all 0.15s;
-    }
-    .saved-item.is-read .saved-item-read { color: #fbbf24 !important; }
-
-    .saved-item:hover .saved-item-edit,
-    .saved-item:hover .saved-item-copy,
-    .saved-item:hover .saved-item-read,
-    .saved-item:hover .saved-item-delete {
-      color: var(--text-muted);
-    }
-
-    .saved-item-edit:hover {
-      color: #c4b5fd !important;
-      background: rgba(167, 139, 250, 0.15);
-    }
-
-    .saved-item-copy:hover {
-      color: #a5f3fc !important;
-      background: rgba(6, 182, 212, 0.15);
-    }
-
-    .saved-item-delete:hover {
-      color: #fca5a5 !important;
-      background: rgba(239, 68, 68, 0.15);
-    }
-
-    .saved-item.is-read { opacity: 0.55; }
-    .saved-item.is-read .saved-item-title {
-      text-decoration: line-through;
-      text-decoration-color: rgba(167,139,250,0.5);
-    }
-    .saved-item-read:hover {
-      color: #fbbf24 !important;
-      background: rgba(251, 191, 36, 0.15);
-    }
-
     /* Tag color picker in modal */
     .tag-colors-row {
       display: flex;
@@ -3148,7 +2888,7 @@
       <div id="topbar-actions" style="flex-direction:column;align-items:flex-end;gap:4px;">
         <div id="public-ip" style="font-size:10px;letter-spacing:0.12em;color:rgba(255,255,255,0.35);text-transform:uppercase;"></div>
         <div style="display:flex;gap:8px;align-items:center;">
-        <button class="icon-btn" id="notes-btn" data-tip="Notes & Kindling">
+        <button class="icon-btn" id="notes-btn" data-tip="Notes">
           <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
             stroke-linecap="round" stroke-linejoin="round">
             <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
@@ -3318,25 +3058,6 @@
     </div>
 
     <div class="help-section">
-      <div class="help-section-title">Kindling</div>
-      <p class="help-p">Your reading list — articles, threads, and pages you'll come back to. Open the notepad icon →
-        Kindling tab. Mark items read once you've finished; filter by <strong>Unread</strong> / <strong>Read</strong> or
-        by tag. The panel can be Light, Dark, or System themed independently of the background.</p>
-      <div class="help-row"><span class="help-row-label">Add from panel</span><span class="help-row-desc">+ Add Link
-          button inside the tab</span></div>
-      <div class="help-row"><span class="help-row-label">Save current tab</span><span class="help-row-desc">Click the
-          Lumina icon in Chrome's toolbar from any page</span></div>
-      <div class="help-row"><span class="help-row-label">Tags</span><span class="help-row-desc">Assign color-coded tags;
-          8 preset colors; create custom tags</span></div>
-      <div class="help-row"><span class="help-row-label">Filter by tag</span><span class="help-row-desc">Click a tag
-          chip in the filter row</span></div>
-      <div class="help-row"><span class="help-row-label">Sort</span><span class="help-row-desc">Newest first or A –
-          Z</span></div>
-      <div class="help-row"><span class="help-row-label">Hover actions</span><span class="help-row-desc">Copy URL ·
-          Delete</span></div>
-    </div>
-
-    <div class="help-section">
       <div class="help-section-title">Weather</div>
       <p class="help-p">Displayed in the top-left corner. Settings → Weather to configure.</p>
       <div class="help-row"><span class="help-row-label">Auto location</span><span class="help-row-desc">"Use my
@@ -3364,8 +3085,8 @@
       <div class="help-row"><span class="help-row-label">Custom wallpaper</span><span class="help-row-desc">Upload one
           or more images; filename becomes the title; edit emoji/title on the card. Only titles and selection sync (not
           image data), so sync stays small.</span></div>
-      <div class="help-row"><span class="help-row-label">Panel theme</span><span class="help-row-desc">Notes/Kindling
-          panel: Dark · Light · System (follows OS)</span></div>
+      <div class="help-row"><span class="help-row-label">Panel theme</span><span class="help-row-desc">Notes panel:
+          Dark · Light · System (follows OS)</span></div>
       <div class="help-row"><span class="help-row-label">Daily Focus</span><span class="help-row-desc">Settings → Daily
           Focus — a manually curated set of focus lines that rotate daily; add your own in Settings</span></div>
       <div class="help-row"><span class="help-row-label">Greeting</span><span class="help-row-desc">Settings → Options —
@@ -3713,7 +3434,6 @@
           </div>
           <div style="font-size:12px;color:var(--text-muted);line-height:1.8;">
             <div>Quick Links: <span id="rd-ql-status" style="color:var(--text);">(not connected)</span></div>
-            <div>Kindling: <span id="rd-kindling-status" style="color:var(--text);">(not connected)</span></div>
           </div>
         </div>
 
@@ -3737,7 +3457,6 @@
       <div class="notes-tabs">
         <button class="notes-tab active" data-tab="notes">Notes</button>
         <button class="notes-tab" data-tab="quicklinks">Quick Links</button>
-        <button class="notes-tab" data-tab="saved">Kindling</button>
       </div>
       <button id="notes-theme-toggle" title="Toggle light/dark" style="background:none;border:none;color:var(--text-muted);cursor:pointer;padding:4px;display:flex;align-items:center;transition:color 0.2s;">
         <svg id="notes-theme-icon" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -3846,67 +3565,6 @@
       <div id="sp-ql-list" style="flex:1;overflow-y:auto;padding:0 12px 12px;"></div>
     </div>
 
-    <!-- SAVED TAB -->
-    <div id="saved-tab-content" class="notes-tab-pane">
-      <div id="saved-add-row">
-        <button id="saved-add-btn">
-          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"
-            stroke-linecap="round">
-            <line x1="12" y1="5" x2="12" y2="19" />
-            <line x1="5" y1="12" x2="19" y2="12" />
-          </svg>
-          Add Link
-        </button>
-      </div>
-      <div id="saved-sort-row" style="display:flex;gap:4px;padding:8px 20px 0;flex-shrink:0;align-items:center;">
-        <button class="saved-sort-btn active" data-sort="date"
-          style="flex:1;padding:5px 8px;border-radius:7px;border:1px solid var(--glass-border);background:rgba(167,139,250,0.15);border-color:rgba(167,139,250,0.3);color:var(--text);font-size:11px;font-weight:500;font-family:'Inter',sans-serif;cursor:pointer;transition:all 0.15s;">Newest</button>
-        <button class="saved-sort-btn" data-sort="title"
-          style="flex:1;padding:5px 8px;border-radius:7px;border:1px solid var(--glass-border);background:var(--glass);color:var(--text-muted);font-size:11px;font-weight:500;font-family:'Inter',sans-serif;cursor:pointer;transition:all 0.15s;">A
-          – Z</button>
-        <div style="width:1px;height:16px;background:var(--glass-border);margin:0 2px;flex-shrink:0;"></div>
-        <button class="fav-bg-btn" data-bg="white" title="Light favicon background"></button>
-        <button class="fav-bg-btn" data-bg="dark" title="Dark favicon background"></button>
-        <button class="fav-bg-btn" data-bg="transparent" title="No favicon background"></button>
-      </div>
-      <div id="saved-filters"></div>
-      <div id="saved-list">
-        <div id="saved-empty">Kindling is empty.<br><small style="opacity:0.6">Add a link from the button above, or
-            click the Lumina icon in Chrome's toolbar on any page to stash it here.</small></div>
-      </div>
-    </div>
-  </div>
-
-  <!-- SAVE LINK MODAL -->
-  <div id="saved-modal" style="display:none" class="modal-backdrop">
-    <div class="modal">
-      <h2 id="saved-modal-heading">Save Link</h2>
-      <div class="field">
-        <label>URL</label>
-        <input type="url" id="saved-modal-url" placeholder="https://example.com" />
-      </div>
-      <div class="field">
-        <label>Title <span style="opacity:0.5;font-size:10px">(optional)</span></label>
-        <input type="text" id="saved-modal-title" placeholder="Page title" />
-      </div>
-      <div class="field">
-        <label>Tags</label>
-        <div class="tag-selector-list" id="saved-tag-list"></div>
-        <div
-          style="font-size:10px;letter-spacing:0.08em;text-transform:uppercase;color:var(--text-muted);margin-bottom:6px;font-weight:600;">
-          New tag color</div>
-        <div class="tag-colors-row" id="saved-tag-colors"></div>
-        <div class="new-tag-row">
-          <input class="new-tag-input" id="saved-new-tag-input" type="text" placeholder="New tag name…"
-            maxlength="24" />
-          <button class="new-tag-add" id="saved-new-tag-add" type="button">Add Tag</button>
-        </div>
-      </div>
-      <div class="modal-actions">
-        <button class="btn btn-ghost" id="saved-modal-cancel">Cancel</button>
-        <button class="btn btn-primary" id="saved-modal-save">Save Link</button>
-      </div>
-    </div>
   </div>
 
   <!-- EXPORT MODAL -->

--- a/v1/newtab.js
+++ b/v1/newtab.js
@@ -35,7 +35,6 @@ const DEFAULT_STATE = {
   notes: null,
   activeNoteId: null,
   addressBook: [],
-  savedFaviconBg: 'white',
 };
 
 let state = JSON.parse(localStorage.getItem('lumina_state') || 'null') || DEFAULT_STATE;
@@ -1850,7 +1849,6 @@ document.addEventListener('keydown', e => {
   if (e.key === 'Escape') {
     hideModal();
     hideExportModal();
-    closeSaveModal();
     closeSettingsPanel();
     closeNotesPanel();
     closeHelpPanel();
@@ -1882,7 +1880,6 @@ document.querySelectorAll('.notes-tab').forEach(tab => {
     document.querySelectorAll('.notes-tab').forEach(t => t.classList.toggle('active', t === tab));
     document.getElementById('notes-tab-content').classList.toggle('active', which === 'notes');
     document.getElementById('quicklinks-tab-content').classList.toggle('active', which === 'quicklinks');
-    document.getElementById('saved-tab-content').classList.toggle('active', which === 'saved');
     if (which === 'quicklinks') renderSidePanelQuickLinks();
   });
 });
@@ -2343,45 +2340,8 @@ document.getElementById('export-copy-btn').addEventListener('click', () => {
   });
 });
 
-// ─── SAVED LINKS ──────────────────────────────────
-const TAG_COLORS = [
-  '#ef4444', '#f97316', '#eab308', '#22c55e',
-  '#14b8a6', '#3b82f6', '#a78bfa', '#ec4899',
-];
-
-let savedData = { links: [], tags: [] };
-let savedFilter = 'all';
-let savedSort = 'date'; // 'date' | 'title'
-let selectedTagsForSave = [];
-let selectedTagColor = TAG_COLORS[6];
-let editingLinkId = null;
-
-async function loadSavedLinks() {
-  if (typeof chrome !== 'undefined' && chrome.storage) {
-    try {
-      const result = await chrome.storage.local.get('lumina_saved');
-      if (result.lumina_saved) savedData = result.lumina_saved;
-      return;
-    } catch (e) { /* fall through */ }
-  }
-  const raw = localStorage.getItem('lumina_saved');
-  if (raw) try { savedData = JSON.parse(raw); } catch (e) {}
-}
-
-async function persistSavedLinks() {
-  if (typeof chrome !== 'undefined' && chrome.storage) {
-    try { await chrome.storage.local.set({ lumina_saved: savedData }); }
-    catch (e) { localStorage.setItem('lumina_saved', JSON.stringify(savedData)); }
-  } else {
-    localStorage.setItem('lumina_saved', JSON.stringify(savedData));
-  }
-}
-
-// ─── Raindrop.io API client ────────────────────
+// ─── Raindrop.io API client ────────────��───────
 const RAINDROP_API = 'https://api.raindrop.io/rest/v1';
-const RAINDROP_COLLECTION_NAME = 'Kindling';
-let raindropSyncInProgress = false;
-
 function getRaindropToken() { return (localStorage.getItem('lumina_raindrop_token') || '').trim(); }
 function setRaindropToken(v) {
   localStorage.setItem('lumina_raindrop_token', (v || '').trim());
@@ -2389,17 +2349,6 @@ function setRaindropToken(v) {
     chrome.storage.local.set({ lumina_raindrop_token: (v || '').trim() }).catch(() => {});
   }
 }
-function getRaindropCollectionId() {
-  try { return JSON.parse(localStorage.getItem('lumina_raindrop_collection') || 'null'); } catch { return null; }
-}
-function setRaindropCollectionId(id) {
-  localStorage.setItem('lumina_raindrop_collection', JSON.stringify(id));
-  if (typeof chrome !== 'undefined' && chrome.storage?.local) {
-    chrome.storage.local.set({ lumina_raindrop_collection: id }).catch(() => {});
-  }
-}
-function isRaindropConfigured() { return !!(getRaindropToken() && getRaindropCollectionId()); }
-
 async function raindropApi(method, path, body) {
   const token = getRaindropToken();
   if (!token) throw new Error('No Raindrop.io token configured');
@@ -2463,506 +2412,9 @@ async function rdDeleteRaindrop(id) {
   return raindropApi('DELETE', `/raindrop/${id}`);
 }
 
-async function ensureRaindropCollection() {
-  const existingId = getRaindropCollectionId();
-  if (existingId) {
-    try {
-      const j = await raindropApi('GET', `/collection/${existingId}`);
-      if (j?.item?._id) return j.item._id;
-    } catch {}
-  }
-  const collections = await rdGetCollections();
-  const found = collections.find(c => c.title === RAINDROP_COLLECTION_NAME);
-  if (found) {
-    setRaindropCollectionId(found._id);
-    return found._id;
-  }
-  const created = await rdCreateCollection(RAINDROP_COLLECTION_NAME);
-  if (created?._id) {
-    setRaindropCollectionId(created._id);
-    return created._id;
-  }
-  throw new Error('Could not create Kindling collection');
-}
-
-function raindropToLocal(rd) {
-  return {
-    id: 'sl-' + rd._id,
-    raindropId: rd._id,
-    url: rd.link,
-    title: rd.title || '',
-    tags: Array.isArray(rd.tags) ? [...rd.tags] : [],
-    savedAt: new Date(rd.created).getTime() || Date.now(),
-    readAt: rd.important ? null : Date.now(),
-    lastUpdate: rd.lastUpdate || rd.created,
-  };
-}
-
-function localToRaindropPayload(link, collectionId) {
-  return {
-    link: link.url,
-    title: link.title || '',
-    collection: { '$id': collectionId },
-    tags: Array.isArray(link.tags) ? [...link.tags] : [],
-    important: !link.readAt,
-  };
-}
-
-async function raindropPullSync() {
-  if (!isRaindropConfigured()) return;
-  if (raindropSyncInProgress) return;
-  raindropSyncInProgress = true;
-  setKindlingStatus('Pulling from Raindrop.io…');
-  try {
-    const collectionId = getRaindropCollectionId();
-    const remoteItems = await rdGetAllRaindrops(collectionId);
-    const remoteById = new Map(remoteItems.map(r => [r._id, r]));
-
-    const localLinks = savedData.links || [];
-    const localByRaindropId = new Map();
-    for (const l of localLinks) {
-      if (l.raindropId) localByRaindropId.set(l.raindropId, l);
-    }
-
-    const merged = [];
-    const processedRemoteIds = new Set();
-
-    for (const rd of remoteItems) {
-      processedRemoteIds.add(rd._id);
-      const local = localByRaindropId.get(rd._id);
-      if (local) {
-        const remoteTime = new Date(rd.lastUpdate || rd.created).getTime();
-        const localTime = local.lastUpdate ? new Date(local.lastUpdate).getTime() : (local.savedAt || 0);
-        if (remoteTime >= localTime) {
-          merged.push({ ...local, ...raindropToLocal(rd) });
-        } else {
-          merged.push(local);
-        }
-      } else {
-        merged.push(raindropToLocal(rd));
-      }
-    }
-
-    for (const local of localLinks) {
-      if (local.raindropId && !processedRemoteIds.has(local.raindropId)) continue;
-      if (!local.raindropId) merged.push(local);
-    }
-
-    const remoteTags = new Set();
-    for (const rd of remoteItems) {
-      if (Array.isArray(rd.tags)) rd.tags.forEach(t => remoteTags.add(t));
-    }
-    for (const tagName of remoteTags) {
-      if (!savedData.tags.find(t => t.name === tagName)) {
-        savedData.tags.push({ name: tagName, color: TAG_COLORS[Math.floor(Math.random() * TAG_COLORS.length)] });
-      }
-    }
-
-    savedData.links = merged;
-    await persistSavedLinksLocal();
-    renderSavedFilters();
-    renderSavedList();
-
-    await raindropPushLocalOnly();
-
-    const t = new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
-    setKindlingStatus(`Synced ${t}`);
-  } catch (err) {
-    setKindlingStatus(`Sync error: ${err.message.slice(0, 60)}`);
-    showToast(`⚠ ${err.message}`);
-  } finally {
-    raindropSyncInProgress = false;
-  }
-}
-
-async function raindropPushLocalOnly() {
-  if (!isRaindropConfigured()) return;
-  const collectionId = getRaindropCollectionId();
-  let dirty = false;
-  for (const link of savedData.links) {
-    if (!link.raindropId) {
-      try {
-        const created = await rdCreateRaindrop(localToRaindropPayload(link, collectionId));
-        if (created?._id) {
-          link.raindropId = created._id;
-          link.id = 'sl-' + created._id;
-          link.lastUpdate = created.lastUpdate || new Date().toISOString();
-          dirty = true;
-        }
-      } catch {}
-    }
-  }
-  if (dirty) await persistSavedLinksLocal();
-}
-
-async function persistSavedLinksLocal() {
-  if (typeof chrome !== 'undefined' && chrome.storage) {
-    try { await chrome.storage.local.set({ lumina_saved: savedData }); }
-    catch (e) { localStorage.setItem('lumina_saved', JSON.stringify(savedData)); }
-  } else {
-    localStorage.setItem('lumina_saved', JSON.stringify(savedData));
-  }
-}
-
-async function raindropSyncOnSave(link, action) {
-  if (!isRaindropConfigured()) return;
-  const collectionId = getRaindropCollectionId();
-  try {
-    if (action === 'create' && !link.raindropId) {
-      const created = await rdCreateRaindrop(localToRaindropPayload(link, collectionId));
-      if (created?._id) {
-        link.raindropId = created._id;
-        link.id = 'sl-' + created._id;
-        link.lastUpdate = created.lastUpdate || new Date().toISOString();
-        await persistSavedLinksLocal();
-      }
-    } else if (action === 'update' && link.raindropId) {
-      const updated = await rdUpdateRaindrop(link.raindropId, {
-        title: link.title || '',
-        tags: link.tags || [],
-        important: !link.readAt,
-      });
-      if (updated?.lastUpdate) {
-        link.lastUpdate = updated.lastUpdate;
-        await persistSavedLinksLocal();
-      }
-    } else if (action === 'delete' && link.raindropId) {
-      await rdDeleteRaindrop(link.raindropId);
-    }
-  } catch (err) {
-    showToast(`⚠ Raindrop sync: ${err.message.slice(0, 60)}`);
-  }
-}
-
-function initKindlingSync() {
-  if (isRaindropConfigured()) {
-    setKindlingStatus('Connected');
-    raindropPullSync();
-  }
-}
-
-function setKindlingStatus(msg) {
-  const el = document.getElementById('rd-kindling-status');
-  if (el) el.textContent = msg;
-}
-
-const SAVED_FAVICON_BG = {
-  white:       'rgba(255,255,255,0.92)',
-  dark:        'rgba(20,15,40,0.75)',
-  transparent: 'transparent',
-};
-
-function applySavedFaviconBg(val) {
-  val = val || 'white';
-  state.savedFaviconBg = val;
-  document.documentElement.style.setProperty('--saved-favicon-bg', SAVED_FAVICON_BG[val] || SAVED_FAVICON_BG.white);
-  document.querySelectorAll('.fav-bg-btn').forEach(b => b.classList.toggle('active', b.dataset.bg === val));
-}
-
-let savedStatusFilter = 'all'; // 'all' | 'unread' | 'read'
-
-function makeStatusChip(label, value) {
-  const chip = document.createElement('button');
-  chip.className = 'saved-filter-chip';
-  chip.textContent = label;
-  if (savedStatusFilter === value) {
-    chip.style.cssText = 'background:rgba(167,139,250,0.2);border-color:rgba(167,139,250,0.4);color:white';
-  }
-  chip.addEventListener('click', () => {
-    savedStatusFilter = value;
-    renderSavedFilters();
-    renderSavedList();
-  });
-  return chip;
-}
-
-function renderSavedFilters() {
-  const container = document.getElementById('saved-filters');
-  container.innerHTML = '';
-
-  container.appendChild(makeStatusChip('All', 'all'));
-  container.appendChild(makeStatusChip('Unread', 'unread'));
-  container.appendChild(makeStatusChip('Read', 'read'));
-
-  const sep = document.createElement('span');
-  sep.style.cssText = 'width:1px;height:14px;background:var(--glass-border);margin:0 2px;align-self:center;flex-shrink:0;';
-  container.appendChild(sep);
-
-  const allChip = document.createElement('button');
-  allChip.className = 'saved-filter-chip';
-  allChip.textContent = 'All tags';
-  if (savedFilter === 'all') {
-    allChip.style.cssText = 'background:rgba(167,139,250,0.2);border-color:rgba(167,139,250,0.4);color:white';
-  }
-  allChip.addEventListener('click', () => { savedFilter = 'all'; renderSavedFilters(); renderSavedList(); });
-  container.appendChild(allChip);
-
-  savedData.tags.forEach(tag => {
-    const chip = document.createElement('button');
-    chip.className = 'saved-filter-chip';
-    if (savedFilter === tag.name) {
-      chip.style.cssText = `background:${tag.color}33;border-color:${tag.color}88;color:${tag.color}`;
-    }
-    const dot = document.createElement('span');
-    dot.style.cssText = `width:7px;height:7px;border-radius:50%;background:${tag.color};flex-shrink:0`;
-    chip.appendChild(dot);
-    chip.appendChild(document.createTextNode(tag.name));
-    chip.addEventListener('click', () => {
-      savedFilter = (savedFilter === tag.name) ? 'all' : tag.name;
-      renderSavedFilters();
-      renderSavedList();
-    });
-    container.appendChild(chip);
-  });
-}
-
-function renderSavedList() {
-  const list = document.getElementById('saved-list');
-  list.innerHTML = '';
-
-  let links = savedData.links;
-  if (savedFilter !== 'all') {
-    links = links.filter(l => l.tags && l.tags.includes(savedFilter));
-  }
-  if (savedStatusFilter === 'unread') {
-    links = links.filter(l => !l.readAt);
-  } else if (savedStatusFilter === 'read') {
-    links = links.filter(l => !!l.readAt);
-  }
-
-  if (!links.length) {
-    const empty = document.createElement('div');
-    empty.id = 'saved-empty';
-    if (savedFilter === 'all' && savedStatusFilter === 'all') {
-      empty.innerHTML = "Kindling is empty.<br><small style=\"opacity:0.6\">Use the bookmark button in any tab to stash from anywhere.</small>";
-    } else if (savedStatusFilter !== 'all' && savedFilter === 'all') {
-      empty.innerHTML = `Nothing ${escHtml(savedStatusFilter)} yet.`;
-    } else {
-      empty.innerHTML = `No links tagged <strong>${escHtml(savedFilter)}</strong>.`;
-    }
-    list.appendChild(empty);
-    return;
-  }
-
-  const sorted = [...links].sort((a, b) => savedSort === 'title'
-    ? (a.title || '').localeCompare(b.title || '')
-    : (b.savedAt || 0) - (a.savedAt || 0));
-
-  sorted.forEach((link, idx) => {
-    const item = document.createElement('a');
-    item.className = 'saved-item' + (link.readAt ? ' is-read' : '');
-    item.href = link.url;
-    item.target = '_blank';
-    item.rel = 'noopener';
-    item.style.animationDelay = `${idx * 0.03}s`;
-
-    const savedFaviconHtml = faviconImgHtml(link.url, link.title, 'saved-item-favicon');
-    const tagsHtml = (link.tags || []).map(tagName => {
-      const tag = savedData.tags.find(t => t.name === tagName);
-      const color = tag ? tag.color : '#a78bfa';
-      return `<span class="saved-tag-chip" style="background:${color}22;color:${color};border-color:${color}44">${escHtml(tagName)}</span>`;
-    }).join('');
-
-    item.innerHTML = `
-      ${savedFaviconHtml}
-      <div class="saved-item-info">
-        <div class="saved-item-title">${escHtml(link.title || getUrlLabel(link.url))}</div>
-        <div class="saved-item-domain">${escHtml(getUrlLabel(link.url))}</div>
-        ${tagsHtml ? `<div class="saved-item-tags">${tagsHtml}</div>` : ''}
-      </div>
-      <div class="saved-item-actions">
-        <button class="saved-item-read" title="${link.readAt ? 'Mark unread' : 'Mark read'}">
-          <svg width="12" height="12" viewBox="0 0 24 24" fill="${link.readAt ? 'currentColor' : 'none'}" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>
-        </button>
-        <button class="saved-item-edit" title="Edit tags">
-          <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z"/></svg>
-        </button>
-        <button class="saved-item-copy" title="Copy URL">
-          <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
-        </button>
-        <button class="saved-item-delete" title="Remove">
-          <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/></svg>
-        </button>
-      </div>
-    `;
-
-    item.querySelector('.saved-item-read').addEventListener('click', e => {
-      e.preventDefault();
-      e.stopPropagation();
-      const target = savedData.links.find(l => l.id === link.id);
-      if (!target) return;
-      target.readAt = target.readAt ? null : Date.now();
-      persistSavedLinks();
-      renderSavedList();
-      raindropSyncOnSave(target, 'update');
-    });
-    item.querySelector('.saved-item-edit').addEventListener('click', e => {
-      e.preventDefault();
-      e.stopPropagation();
-      openSaveModal({ id: link.id, url: link.url, title: link.title, tags: link.tags });
-    });
-    item.querySelector('.saved-item-copy').addEventListener('click', e => {
-      e.preventDefault();
-      e.stopPropagation();
-      navigator.clipboard.writeText(link.url).then(() => showCopyToast());
-    });
-    item.querySelector('.saved-item-delete').addEventListener('click', e => {
-      e.preventDefault();
-      e.stopPropagation();
-      const toDelete = savedData.links.find(l => l.id === link.id);
-      savedData.links = savedData.links.filter(l => l.id !== link.id);
-      persistSavedLinks();
-      renderSavedList();
-      if (toDelete) raindropSyncOnSave(toDelete, 'delete');
-    });
-
-    list.appendChild(item);
-  });
-}
-
-// ── Save link modal ──────────────────────────────
-function openSaveModal(prefill = {}) {
-  editingLinkId = prefill.id || null;
-  selectedTagsForSave = Array.isArray(prefill.tags) ? [...prefill.tags] : [];
-  selectedTagColor = TAG_COLORS[6];
-  document.getElementById('saved-modal-url').value = prefill.url || '';
-  document.getElementById('saved-modal-title').value = prefill.title || '';
-  document.getElementById('saved-modal-heading').textContent = editingLinkId ? 'Edit Link' : 'Save Link';
-  document.getElementById('saved-modal-save').textContent = editingLinkId ? 'Save Changes' : 'Save Link';
-  renderSaveTagSelector();
-
-  const m = document.getElementById('saved-modal');
-  m.style.display = 'flex';
-  m.classList.remove('closing');
-  m.querySelector('.modal').classList.remove('closing');
-  setTimeout(() => {
-    const urlEl = document.getElementById('saved-modal-url');
-    (urlEl.value ? document.getElementById('saved-modal-title') : urlEl).focus();
-  }, 50);
-}
-
-function closeSaveModal() {
-  const m = document.getElementById('saved-modal');
-  m.classList.add('closing');
-  m.querySelector('.modal').classList.add('closing');
-  setTimeout(() => { m.style.display = 'none'; }, 200);
-  editingLinkId = null;
-}
-
-function renderSaveTagSelector() {
-  const tagList = document.getElementById('saved-tag-list');
-  tagList.innerHTML = '';
-  savedData.tags.forEach(tag => {
-    const btn = document.createElement('button');
-    btn.className = 'tag-toggle' + (selectedTagsForSave.includes(tag.name) ? ' selected' : '');
-    btn.style.cssText = `background:${tag.color}22;color:${tag.color};border-color:${tag.color}66`;
-    btn.textContent = tag.name;
-    btn.type = 'button';
-    btn.addEventListener('click', () => {
-      const idx = selectedTagsForSave.indexOf(tag.name);
-      if (idx >= 0) selectedTagsForSave.splice(idx, 1);
-      else selectedTagsForSave.push(tag.name);
-      renderSaveTagSelector();
-    });
-    tagList.appendChild(btn);
-  });
-
-  const swatchRow = document.getElementById('saved-tag-colors');
-  swatchRow.innerHTML = '';
-  TAG_COLORS.forEach(color => {
-    const swatch = document.createElement('button');
-    swatch.className = 'tag-color-swatch' + (selectedTagColor === color ? ' selected' : '');
-    swatch.style.background = color;
-    swatch.type = 'button';
-    swatch.addEventListener('click', () => { selectedTagColor = color; renderSaveTagSelector(); });
-    swatchRow.appendChild(swatch);
-  });
-}
-
-function addSaveTag() {
-  const input = document.getElementById('saved-new-tag-input');
-  const name = input.value.trim();
-  if (!name) return;
-  if (!savedData.tags.find(t => t.name === name)) {
-    savedData.tags.push({ name, color: selectedTagColor });
-  }
-  if (!selectedTagsForSave.includes(name)) selectedTagsForSave.push(name);
-  input.value = '';
-  renderSaveTagSelector();
-  renderSavedFilters();
-}
-
-document.getElementById('saved-add-btn').addEventListener('click', () => openSaveModal());
-
-document.querySelectorAll('.saved-sort-btn').forEach(btn => {
-  btn.addEventListener('click', () => {
-    savedSort = btn.dataset.sort;
-    document.querySelectorAll('.saved-sort-btn').forEach(b => {
-      const active = b.dataset.sort === savedSort;
-      b.style.background = active ? 'rgba(167,139,250,0.15)' : 'var(--glass)';
-      b.style.borderColor = active ? 'rgba(167,139,250,0.3)' : 'var(--glass-border)';
-      b.style.color = active ? 'var(--text)' : 'var(--text-muted)';
-    });
-    renderSavedList();
-  });
-});
-
-document.querySelectorAll('.fav-bg-btn').forEach(btn => {
-  btn.addEventListener('click', () => {
-    applySavedFaviconBg(btn.dataset.bg);
-    saveState();
-  });
-});
-document.getElementById('saved-modal-cancel').addEventListener('click', closeSaveModal);
-document.getElementById('saved-modal').addEventListener('click', e => {
-  if (e.target === document.getElementById('saved-modal')) closeSaveModal();
-});
-document.getElementById('saved-new-tag-add').addEventListener('click', addSaveTag);
-document.getElementById('saved-new-tag-input').addEventListener('keydown', e => {
-  if (e.key === 'Enter') { e.preventDefault(); addSaveTag(); }
-});
-
-document.getElementById('saved-modal-save').addEventListener('click', async () => {
-  let url = document.getElementById('saved-modal-url').value.trim();
-  let title = document.getElementById('saved-modal-title').value.trim();
-  if (!url) { showToast('Please enter a URL'); return; }
-  if (!/^https?:\/\//i.test(url)) url = 'https://' + url;
-  if (!title) title = getUrlLabel(url);
-
-  let targetLink;
-  if (editingLinkId) {
-    targetLink = savedData.links.find(l => l.id === editingLinkId);
-    if (targetLink) {
-      targetLink.url = url;
-      targetLink.title = title;
-      targetLink.tags = [...selectedTagsForSave];
-    }
-  } else {
-    targetLink = {
-      id: 'sl-' + Date.now(),
-      url, title,
-      tags: [...selectedTagsForSave],
-      savedAt: Date.now(),
-    };
-    savedData.links.push(targetLink);
-  }
-  const wasEdit = !!editingLinkId;
-  await persistSavedLinks();
-  closeSaveModal();
-  renderSavedFilters();
-  renderSavedList();
-  showToast(wasEdit ? '✓ Link updated' : '✓ Link saved');
-  if (targetLink) raindropSyncOnSave(targetLink, wasEdit ? 'update' : 'create');
-});
-
-// Listen for popup saves
+// Listen for pending quick links from context menu
 if (typeof chrome !== 'undefined' && chrome.storage && chrome.storage.onChanged) {
   chrome.storage.onChanged.addListener((changes, area) => {
-    if (area === 'local' && changes.lumina_saved) {
-      savedData = changes.lumina_saved.newValue || { links: [], tags: [] };
-      renderSavedFilters();
-      renderSavedList();
-    }
     if (area === 'local' && changes.lumina_pending_quicklinks) {
       consumePendingQuickLinks();
     }
@@ -3259,36 +2711,28 @@ function initRaindropSettings() {
   connectBtn?.addEventListener('click', async () => {
     try {
       setQLStatus('Connecting…');
-      setKindlingStatus('Connecting…');
       const token = tokenInput.value.trim();
       if (!token) throw new Error('Enter a test token');
       setRaindropToken(token);
       const qlCol = await qlFindOrCreateCollection();
       if (qlCol?._id) { setQLCollectionId(qlCol._id); setQLStatus('Connected'); }
-      const kCol = await ensureRaindropCollection();
-      if (kCol) setKindlingStatus('Connected');
-      await Promise.all([qlPullSync(), raindropPullSync()]);
+      await qlPullSync();
     } catch (err) {
       setQLStatus(err.message);
-      setKindlingStatus(err.message);
     }
   });
 
   disconnectBtn?.addEventListener('click', () => {
     setRaindropToken('');
     setQLCollectionId(null);
-    setRaindropCollectionId(null);
     tokenInput.value = '';
     setQLStatus('(not connected)');
-    setKindlingStatus('(not connected)');
   });
 
   syncBtn?.addEventListener('click', () => {
     if (isQLConfigured()) qlPullSync();
-    if (isRaindropConfigured()) raindropPullSync();
   });
 
-  initKindlingSync();
   initQLSync();
 }
 
@@ -3319,57 +2763,6 @@ function buildQuickLinksMarkdown() {
     md += `- [${link.label}](${link.url})\n`;
   }
   return md;
-}
-
-function buildSavedLinksMarkdown() {
-  const links = savedData?.links || [];
-  const tags = savedData?.tags || [];
-  if (!links.length) return '# Kindling\n\n_Empty_\n';
-
-  let md = '# Kindling\n\n';
-
-  // Group by tags
-  const tagMap = new Map();
-  const untagged = [];
-  for (const link of links) {
-    if (!link.tags?.length) { untagged.push(link); continue; }
-    for (const tag of link.tags) {
-      if (!tagMap.has(tag)) tagMap.set(tag, []);
-      tagMap.get(tag).push(link);
-    }
-  }
-
-  // Render tagged sections (in tag definition order)
-  for (const tag of tags) {
-    const items = tagMap.get(tag.name);
-    if (!items?.length) continue;
-    md += `## ${tag.name}\n\n`;
-    for (const link of items) {
-      md += `- [${link.readAt ? 'x' : ' '}] [${link.title}](${link.url})\n`;
-    }
-    md += '\n';
-  }
-
-  // Render any tags not in the tags list
-  for (const [tagName, items] of tagMap) {
-    if (tags.find(t => t.name === tagName)) continue;
-    md += `## ${tagName}\n\n`;
-    for (const link of items) {
-      md += `- [${link.readAt ? 'x' : ' '}] [${link.title}](${link.url})\n`;
-    }
-    md += '\n';
-  }
-
-  // Render untagged
-  if (untagged.length) {
-    md += `## Untagged\n\n`;
-    for (const link of untagged) {
-      md += `- [${link.readAt ? 'x' : ' '}] [${link.title}](${link.url})\n`;
-    }
-    md += '\n';
-  }
-
-  return md.trimEnd() + '\n';
 }
 
 function downloadTextFile(filename, text, mime) {
@@ -3505,12 +2898,6 @@ function init() {
 
   // Restore sidebar states
   if (state.notesPanelOpen !== false) openNotesPanel();
-  applySavedFaviconBg(state.savedFaviconBg || 'white');
-  loadSavedLinks().then(() => {
-    renderSavedFilters();
-    renderSavedList();
-    initKindlingSync();
-  });
 
   initRaindropSettings();
   initSidePanelQuickLinks();


### PR DESCRIPTION
Closes #27

## Summary
Remove the Kindling (reading list / saved links) feature entirely from v1. Quick Links continues to sync with Raindrop.io. The side panel menu is now just Notes — the Kindling tab, saved modal, and all associated CSS/JS have been removed (~1,029 lines deleted across 3 files).

## Testing
- `node -c v1/newtab.js` — syntax check passes
- `node -c v1/background.js` — syntax check passes
- Verified no remaining references to Kindling, savedData, savedLinks, closeSaveModal, buildSavedLinksMarkdown, initKindlingSync, or related identifiers across the entire v1 directory
- Quick Links export functionality confirmed intact
- Raindrop.io connect/disconnect/sync handlers updated to only reference Quick Links